### PR TITLE
fixed compilation errors

### DIFF
--- a/coderedlib.cpp
+++ b/coderedlib.cpp
@@ -7,6 +7,7 @@
 #include <bitset>
 #include <assert.h>
 #include <time.h>
+#include <array>
 #include <unistd.h>
 
 using namespace std;

--- a/compile_cpp_core.sh
+++ b/compile_cpp_core.sh
@@ -2,9 +2,9 @@
 
 rm -rf bin
 mkdir bin
-# for i in 1280
-for i in 256 384 512 768 1024 1280 1536 2048 3072 4096 6144 8192 12288 16384 24576 32768 49152 65536
+
+for i in 256 384 512 768 1024 1280 1536 2048 3072 4096 6144 8192 10240 12288 16384 24576 32768 49152 65536
 do
-	g++ -fPIC -march=native -O3 -funroll-loops -std=c++14 -c -Dmaxn=$i coderedlib.cpp -o bin/coderedlib-$i.o
+	g++ -fPIC  -O3 -march=native -funroll-loops -std=c++14 -c -Dmaxn=$i coderedlib.cpp -o bin/coderedlib-$i.o # -march=native might not be supported on arm 
 	g++ -shared -O3 -march=native -funroll-loops -std=c++14 bin/coderedlib-$i.o -o bin/coderedlib-$i.so
 done


### PR DESCRIPTION
added missing include <array>
also --march=native does not work for arm64  on old versions of clang